### PR TITLE
workaround for groups syntax bug in cloud-init

### DIFF
--- a/domain/create/defaults/main.yml
+++ b/domain/create/defaults/main.yml
@@ -71,7 +71,7 @@ libvirt_domain:
       ssh-authorized-keys: [] # required!
       shell: '/bin/bash'
       sudo: 'ALL=(ALL) NOPASSWD:ALL'
-      groups: 'adm, audio, cdrom, dialout, floppy, video, plugdev, dip, netdev' # comma separated string!
+      groups: 'adm,audio,cdrom,dialout,floppy,video,plugdev,dip,netdev' # comma separated string!
 
   #
   # ConfigDrive
@@ -192,7 +192,7 @@ libvirt_cloud_config_default_user:
   ssh-authorized-keys: [] # required!
   shell: '/bin/bash'
   sudo: 'ALL=(ALL) NOPASSWD:ALL'
-  groups: 'adm, audio, cdrom, dialout, floppy, video, plugdev, dip, netdev' # comma separated string!
+  groups: 'adm,audio,cdrom,dialout,floppy,video,plugdev,dip,netdev' # comma separated string!
 
 #
 # ConfigDrive


### PR DESCRIPTION
Workaround for the bug in cloud-init https://bugs.launchpad.net/cloud-init/+bug/1356208 also described here https://github.com/lxc/lxd/issues/1597
